### PR TITLE
Add readme on unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Download prebuilt binaries from https://github.com/git-lfs-fuse/git-lfs-fuse/rel
 git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
 ```
 
+### Clean up and unmount
+
+If a user-space program crashes during a FUSE operation, or if `git-lfs-fuse` encounters an error, the FUSE module may get stuck in kernel space, preventing clean shutdown.
+In such cases, you may need to manually unmount the FUSE mount point:
+```sh
+sudo fusermount3 -u <mount-dir> 
+```
+
 ## Requirements
 
 - FUSE support on your operating system (Linux, Windows WSL 2, macOS with [macFUSE](https://macfuse.github.io/) installed).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
 If a user-space program crashes during a FUSE operation, or if `git-lfs-fuse` encounters an error, the FUSE module may get stuck in kernel space, preventing clean shutdown.
 In such cases, you may need to manually unmount the FUSE mount point:
 ```sh
+# Linux.
 sudo fusermount3 -u <mount-dir> 
 ```
 


### PR DESCRIPTION
It's easy to reproduce the situation fuse module gets trapped, you simply send `SIGINT` to a running program which reads remote object via `git-lfs-fuse`; add a short sentence to document the recovery solution.