### PR TITLE
docs: add Chinese README translations and improve main README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # git-lfs-fuse
 
+[繁體中文](README.zh-TW.md) | [簡體中文](README.zh-CN.md)
+
 Mount remote repositories and datasets managed by Git LFS locally.
 
 ## Features
@@ -11,7 +13,7 @@ Mount remote repositories and datasets managed by Git LFS locally.
 
 ### Installation
 
-Download prebuilt binaries from https://github.com/git-lfs-fuse/git-lfs-fuse/releases.
+Download prebuilt binaries from [release page](https://github.com/git-lfs-fuse/git-lfs-fuse/releases).
 
 ### Mount your repository or dataset
 
@@ -22,11 +24,11 @@ git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
 
 ### Clean up and unmount
 
-If a user-space program crashes during a FUSE operation, or if `git-lfs-fuse` encounters an error, the FUSE module may get stuck in kernel space, preventing clean shutdown.
-In such cases, you may need to manually unmount the FUSE mount point:
+If a user-space program crashes during a FUSE operation, or if `git-lfs-fuse` encounters an error, the FUSE module may get stuck in kernel space, preventing clean shutdown. In such cases, you may need to manually unmount the FUSE mount point:
+
 ```sh
 # Linux.
-sudo fusermount3 -u <mount-dir> 
+sudo fusermount3 -u <mount-dir>
 ```
 
 ## Requirements
@@ -36,10 +38,9 @@ sudo fusermount3 -u <mount-dir>
 
 ## Roadmap
 
-* NFS v3 or v4.
-* Git submodule.
+- NFS v3 or v4.
+- Git submodule.
 
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,47 @@
+# git-lfs-fuse
+
+[English](README.md) | [繁體中文](README.zh-TW.md)
+
+将由 Git LFS 管理的远程仓库与数据集挂载到本地。
+
+## 功能特性
+
+- **更快的克隆与签出**：Git LFS 跟踪的文件会以分页（每页 2MiB）按需下载。
+- **适用于有限存储空间**：分页会缓存在本地，并受 `max-pages` 配置（默认：5120）限制。
+
+## 快速开始
+
+### 安装
+
+请从 [release page](https://github.com/git-lfs-fuse/git-lfs-fuse/releases) 下载预编译二进制文件。
+
+### 挂载您的仓库或数据集
+
+```bash
+# 例如，挂载 huggingface 数据集：
+git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
+```
+
+### 清理与卸载
+
+如果用户空间程序在 FUSE 操作期间崩溃，或 `git-lfs-fuse` 发生错误，FUSE 模块可能会卡在内核空间，导致无法正常关闭。
+此时，您可能需要手动卸载 FUSE 挂载点：
+
+```sh
+# Linux.
+sudo fusermount3 -u <mount-dir>
+```
+
+## 系统要求
+
+- 操作系统需支持 FUSE（Linux、Windows WSL 2、安装了 [macFUSE](https://macfuse.github.io/) 的 macOS）。
+- 已安装并配置 Git LFS。
+
+## 路线图
+
+- NFS v3 或 v4。
+- Git 子模块。
+
+## 贡献
+
+欢迎贡献！请随时提交 Pull Request。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,47 @@
+# git-lfs-fuse
+
+[English](README.md) | [簡體中文](README.zh-CN.md)
+
+將由 Git LFS 管理的遠端儲存庫與資料集掛載於本地端。
+
+## 功能特色
+
+- **更快的克隆與簽出**：Git LFS 追蹤的檔案會以分頁（每頁 2MiB）按需下載。
+- **適用於有限儲存空間**：分頁會快取於本地端，並受 `max-pages` 設定（預設：5120）限制。
+
+## 快速開始
+
+### 安裝
+
+請從 [release page](https://github.com/git-lfs-fuse/git-lfs-fuse/releases) 下載預建二進位檔。
+
+### 掛載您的儲存庫或資料集
+
+```bash
+# 例如，掛載 huggingface 資料集：
+git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
+```
+
+### 清理與卸載
+
+如果使用者空間程式在 FUSE 操作期間崩潰，或 `git-lfs-fuse` 發生錯誤，FUSE 模組可能會卡在核心空間，導致無法正常關閉。
+此時，您可能需要手動卸載 FUSE 掛載點：
+
+```sh
+# Linux.
+sudo fusermount3 -u <mount-dir>
+```
+
+## 系統需求
+
+- 作業系統需支援 FUSE（Linux、Windows WSL 2、安裝 [macFUSE](https://macfuse.github.io/) 的 macOS）。
+- 已安裝並設定 Git LFS。
+
+## 發展藍圖
+
+- NFS v3 或 v4。
+- Git 子模組。
+
+## 貢獻
+
+歡迎貢獻！請隨時提交 Pull Request。


### PR DESCRIPTION
- Add links to Traditional and Simplified Chinese README translations at the top of the main README
- Update download instructions to use a markdown link for the release page
- Merge two sentences about FUSE module errors into one and add a line break for clarity
- Fix formatting of roadmap items to use consistent markdown list style
- Remove trailing empty line at the end of the README
- Add a new README in Simplified Chinese
- Add a new README in Traditional Chinese