### PR TITLE
docs: refine and clarify documentation in all README files

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,10 @@
 # git-lfs-fuse
 
-[English](README.md) | [繁體中文](README.zh-TW.md)
+[![codecov](https://codecov.io/gh/git-lfs-fuse/git-lfs-fuse/graph/badge.svg?token=9EXOUDNEFC)](https://codecov.io/gh/git-lfs-fuse/git-lfs-fuse)
 
-将由 Git LFS 管理的远程仓库与数据集挂载到本地。
+[繁體中文](README.zh-TW.md) | [English](README.md)
+
+将由 Git LFS 管理的远程仓库、模型和数据集挂载到本地。
 
 ## 功能特性
 
@@ -11,31 +13,32 @@
 
 ## 快速开始
 
+### 系统要求
+
+- 操作系统需支持 FUSE（Linux、Windows WSL 2、安装了 [macFUSE](https://macfuse.github.io/) 的 macOS）。
+- 已安装并配置 Git LFS。
+
 ### 安装
 
 请从 [release page](https://github.com/git-lfs-fuse/git-lfs-fuse/releases) 下载预编译二进制文件。
 
-### 挂载您的仓库或数据集
+### 挂载您的仓库、模型或数据集
 
 ```bash
 # 例如，挂载 huggingface 数据集：
-git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
+git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning --max-pages 5120
 ```
 
 ### 清理与卸载
 
-如果用户空间程序在 FUSE 操作期间崩溃，或 `git-lfs-fuse` 发生错误，FUSE 模块可能会卡在内核空间，导致无法正常关闭。
-此时，您可能需要手动卸载 FUSE 挂载点：
+如果 `git-lfs-fuse` 未正常退出，FUSE 模块可能会卡在内核空间。此时，您可能需要手动卸载 FUSE 挂载点：
 
 ```sh
 # Linux.
 sudo fusermount3 -u <mount-dir>
+# macOS.
+sudo diskutil unmount <mount-dir>
 ```
-
-## 系统要求
-
-- 操作系统需支持 FUSE（Linux、Windows WSL 2、安装了 [macFUSE](https://macfuse.github.io/) 的 macOS）。
-- 已安装并配置 Git LFS。
 
 ## 路线图
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,41 +1,44 @@
 # git-lfs-fuse
 
+[![codecov](https://codecov.io/gh/git-lfs-fuse/git-lfs-fuse/graph/badge.svg?token=9EXOUDNEFC)](https://codecov.io/gh/git-lfs-fuse/git-lfs-fuse)
+
 [English](README.md) | [簡體中文](README.zh-CN.md)
 
-將由 Git LFS 管理的遠端儲存庫與資料集掛載於本地端。
+將由 Git LFS 管理的遠端儲存庫、模型和資料集掛載於本地端。
 
 ## 功能特色
 
-- **更快的克隆與簽出**：Git LFS 追蹤的檔案會以分頁（每頁 2MiB）按需下載。
+- **更快的複製與簽出**：Git LFS 追蹤的檔案會以分頁（每頁 2MiB）按需下載。
 - **適用於有限儲存空間**：分頁會快取於本地端，並受 `max-pages` 設定（預設：5120）限制。
 
 ## 快速開始
+
+### 系統需求
+
+- 作業系統需支援 FUSE（Linux、Windows WSL 2、安裝了 [macFUSE](https://macfuse.github.io/) 的 macOS）。
+- 已安裝並設定 Git LFS。
 
 ### 安裝
 
 請從 [release page](https://github.com/git-lfs-fuse/git-lfs-fuse/releases) 下載預建二進位檔。
 
-### 掛載您的儲存庫或資料集
+### 掛載您的儲存庫、模型或資料集
 
 ```bash
 # 例如，掛載 huggingface 資料集：
-git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning
+git-lfs-fuse mount https://huggingface.co/datasets/nvidia/OpenCodeReasoning --max-pages 5120
 ```
 
 ### 清理與卸載
 
-如果使用者空間程式在 FUSE 操作期間崩潰，或 `git-lfs-fuse` 發生錯誤，FUSE 模組可能會卡在核心空間，導致無法正常關閉。
-此時，您可能需要手動卸載 FUSE 掛載點：
+若 `git-lfs-fuse` 未正常結束，FUSE 模組可能會卡在核心空間。此時，您可能需要手動卸載 FUSE 掛載點：
 
 ```sh
 # Linux.
 sudo fusermount3 -u <mount-dir>
+# macOS.
+sudo diskutil unmount <mount-dir>
 ```
-
-## 系統需求
-
-- 作業系統需支援 FUSE（Linux、Windows WSL 2、安裝 [macFUSE](https://macfuse.github.io/) 的 macOS）。
-- 已安裝並設定 Git LFS。
 
 ## 發展藍圖
 


### PR DESCRIPTION
- Add code coverage badge to both Chinese README files
- Clarify that repository, models, and datasets managed by Git LFS can be mounted locally
- Improve the order and visibility of language navigation links
- Add a "System Requirements" section listing supported operating systems and the need for Git LFS
- Update example commands to include the --max-pages argument
- Adjust section and heading titles to consistently refer to repository, model, or dataset
- Improve instructions for manually unmounting FUSE, adding macOS-specific commands
- Revise language in troubleshooting FUSE module lockups for clarity
- Remove duplicate or misplaced system requirements section at the end of each README