### PR TITLE
feat: lookup the .git/lfs/objects before downloading remote parts

### DIFF
--- a/node.go
+++ b/node.go
@@ -398,6 +398,7 @@ func NewGitLFSFuseRoot(rootPath string, cfg *config.Configuration, maxPages int6
 		manifest:  manifest,
 		pl:        pl,
 		pr:        pr,
+		po:        filepath.Join(rootPath, ".git", "lfs", "objects"),
 		lru:       lru,
 		maxPages:  maxPages,
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -448,7 +448,7 @@ func TestLocalFileWrite(t *testing.T) {
 		t.Fatalf("mnt file content mismatch: got %q, want %q", mntContent, newContent)
 	}
 
-	// create new local file
+	// create a new local file
 	newFilePath := filepath.Join(mnt, "normal3.txt")
 	f, err := os.Create(newFilePath)
 	if err != nil {
@@ -552,10 +552,6 @@ func TestRemoteFileWrite(t *testing.T) {
 		t.Fatalf("git commit error: %v", err)
 	}
 
-	if _, err := run(mnt, "git", "push", "-u", "origin", "main"); err != nil {
-		t.Fatalf("git push error: %v", err)
-	}
-
 	// checkout back to the original branch (main) to refresh the new pointer files
 	if _, err := run(mnt, "git", "checkout", "-f", "branch2"); err != nil {
 		t.Fatal(err)
@@ -566,6 +562,10 @@ func TestRemoteFileWrite(t *testing.T) {
 
 	_ = verifyRemoteFile(t, hid, mnt, "emptylarge.bin")
 	_ = verifyRemoteFile(t, hid, mnt, "emptylarge3.bin")
+
+	if _, err := run(mnt, "git", "push", "-u", "origin", "main"); err != nil {
+		t.Fatalf("git push error: %v", err)
+	}
 
 	// Clone the remote repository to verify the pushed content.
 	cloneDir, err := os.MkdirTemp("", "remote-check")


### PR DESCRIPTION
Local git-lfs files added by the `git add` will be copied to `.git/lfs/objects`. We should treat it as a remote as well.